### PR TITLE
ablity to specify default queue type

### DIFF
--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/WorkerConfiguration.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/WorkerConfiguration.java
@@ -19,8 +19,24 @@ package com.agorapulse.worker;
 
 public interface WorkerConfiguration {
 
-    WorkerConfiguration ENABLED = () -> true;
+    WorkerConfiguration ENABLED = new WorkerConfiguration() {
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+
+        @Override
+        public String getQueueType() {
+            return null;
+        }
+
+    };
 
     boolean isEnabled();
+
+    /**
+     * @return the default queue type such as <code>local</code> or <code>sqs</code>
+     */
+    String getQueueType();
 
 }

--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/configuration/DefaultJobConfiguration.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/configuration/DefaultJobConfiguration.java
@@ -142,6 +142,8 @@ public class DefaultJobConfiguration implements MutableJobConfiguration {
 
     public DefaultJobConfiguration(@Parameter String name, WorkerConfiguration workerConfiguration) {
         this.enabled = workerConfiguration.isEnabled();
+        this.consumer.setQueueType(workerConfiguration.getQueueType());
+        this.producer.setQueueType(workerConfiguration.getQueueType());
         this.name = name;
     }
 

--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/configuration/DefaultWorkerConfiguration.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/configuration/DefaultWorkerConfiguration.java
@@ -25,6 +25,7 @@ import io.micronaut.context.env.Environment;
 public class DefaultWorkerConfiguration implements WorkerConfiguration {
 
     private boolean enabled;
+    private String queueType;
 
     public DefaultWorkerConfiguration(Environment env) {
         // disable for tests and functions
@@ -40,4 +41,12 @@ public class DefaultWorkerConfiguration implements WorkerConfiguration {
         this.enabled = enabled;
     }
 
+    @Override
+    public String getQueueType() {
+        return queueType;
+    }
+
+    public void setQueueType(String queueType) {
+        this.queueType = queueType;
+    }
 }

--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalJobExecutor.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalJobExecutor.java
@@ -18,7 +18,7 @@
 package com.agorapulse.worker.local;
 
 import com.agorapulse.worker.executor.DistributedJobExecutor;
-import io.micronaut.retry.annotation.Fallback;
+import io.micronaut.context.annotation.Secondary;
 import io.reactivex.Maybe;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Fallback
+@Secondary
 @Singleton
 public class LocalJobExecutor implements DistributedJobExecutor {
 

--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalQueues.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalQueues.java
@@ -18,9 +18,9 @@
 package com.agorapulse.worker.local;
 
 import com.agorapulse.worker.queue.JobQueues;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
-import io.micronaut.retry.annotation.Fallback;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 
-@Fallback
+@Secondary
 @Singleton
 @Named("local")
 public class LocalQueues implements JobQueues {

--- a/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/WorkerConfigurationSpec.groovy
+++ b/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/WorkerConfigurationSpec.groovy
@@ -1,0 +1,40 @@
+package com.agorapulse.worker
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import javax.inject.Inject
+import javax.inject.Named
+
+class WorkerConfigurationSpec extends Specification {
+
+    @AutoCleanup ApplicationContext context
+
+    @Inject WorkerConfiguration workerConfiguration
+    @Inject @Named('one') JobConfiguration one
+    @Inject @Named('two') JobConfiguration two
+
+    void setup() {
+        context = ApplicationContext.build(
+            'worker.enabled': true,
+            'worker.queue-type': 'foo',
+            'worker.jobs.one.consumer.queue-type': 'bar',
+            'worker.jobs.two.producer.queue-type': 'bar'
+        ).build()
+
+        context.start()
+        context.inject(this)
+    }
+
+    void 'check configuration'() {
+        expect:
+            workerConfiguration.enabled
+            workerConfiguration.queueType == 'foo'
+            one.consumer.queueType == 'bar'
+            one.producer.queueType == 'foo'
+            two.consumer.queueType == 'foo'
+            two.producer.queueType == 'bar'
+    }
+
+}


### PR DESCRIPTION
Added an optional `worker.queue-type` configuration property to set the default queue type. This should enable for example `worker.queue-local` for the local development to disable SQS implementation.