### PR TITLE
Wrap cron expression issues into appropriate exception

### DIFF
--- a/libs/micronaut-worker-executor-redis/src/main/java/com/agorapulse/worker/redis/RedisJobExecutor.java
+++ b/libs/micronaut-worker-executor-redis/src/main/java/com/agorapulse/worker/redis/RedisJobExecutor.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Callable;
 
 @Singleton
 @Requires(beans = {StatefulRedisConnection.class}, property = "redis.uri")
+@Requires(property = "worker.executor.redis.enabled", value = "true", defaultValue = "true")
 public class RedisJobExecutor implements DistributedJobExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisJobExecutor.class);

--- a/libs/micronaut-worker-executor-redis/src/test/groovy/com/agorapulse/worker/redis/RedisJobExecutorSpec.groovy
+++ b/libs/micronaut-worker-executor-redis/src/test/groovy/com/agorapulse/worker/redis/RedisJobExecutorSpec.groovy
@@ -25,7 +25,7 @@ import org.testcontainers.spock.Testcontainers
 import spock.lang.Retry
 import spock.lang.Shared
 
-@Retry
+@Retry(delay = 500)
 @Testcontainers
 class RedisJobExecutorSpec extends AbstractJobExecutorSpec {
 

--- a/libs/micronaut-worker-queues-redis/src/main/java/com/agorapulse/worker/queues/redis/RedisQueuesFactory.java
+++ b/libs/micronaut-worker-queues-redis/src/main/java/com/agorapulse/worker/queues/redis/RedisQueuesFactory.java
@@ -35,6 +35,7 @@ public class RedisQueuesFactory {
     @Bean
     @Singleton
     @Named("redis")
+    @Requires(property = "worker.queues.redis.enabled", value = "true", defaultValue = "true")
     public JobQueues redisQueues(
             RedisClient redisClient,
             ObjectMapper mapper,

--- a/libs/micronaut-worker-queues-redis/src/test/groovy/com/agorapulse/worker/queues/redis/RedisQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-redis/src/test/groovy/com/agorapulse/worker/queues/redis/RedisQueuesSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Shared
 /**
  * Tests for Redis queues.
  */
-@Retry
+@Retry(delay = 500)
 @MicronautTest(environments = QUEUE_SPEC_ENV_NAME)
 class RedisQueuesSpec extends AbstractQueuesSpec implements TestPropertyProvider {
 

--- a/libs/micronaut-worker-queues-sqs-v1/src/main/java/com/agorapulse/worker/sqs/v1/SqsQueuesFactory.java
+++ b/libs/micronaut-worker-queues-sqs-v1/src/main/java/com/agorapulse/worker/sqs/v1/SqsQueuesFactory.java
@@ -42,6 +42,7 @@ public class SqsQueuesFactory {
     @Bean
     @Singleton
     @Named("sqs")
+    @Requires(property = "worker.queues.sqs.enabled", value = "true", defaultValue = "true")
     public JobQueues sqsQueues(
             AWSCredentialsProvider provider,
             ObjectMapper mapper,

--- a/libs/micronaut-worker-queues-sqs-v2/src/main/java/com/agorapulse/worker/sqs/v2/SqsQueuesFactory.java
+++ b/libs/micronaut-worker-queues-sqs-v2/src/main/java/com/agorapulse/worker/sqs/v2/SqsQueuesFactory.java
@@ -42,6 +42,7 @@ public class SqsQueuesFactory {
     @Bean
     @Singleton
     @Named("sqs")
+    @Requires(property = "worker.queues.sqs.enabled", value = "true", defaultValue = "true")
     public JobQueues sqsQueues(
             AwsCredentialsProvider provider,
             ObjectMapper mapper,

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/executor/AbstractJobExecutorSpec.groovy
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/executor/AbstractJobExecutorSpec.groovy
@@ -31,8 +31,8 @@ abstract class AbstractJobExecutorSpec extends Specification {
     public static final long LONG_RUNNING_JOB_DURATION = 500
 
     private final PollingConditions conditions = new PollingConditions(
-        timeout: 10,
-        initialDelay: 1
+        timeout: 30,
+        initialDelay: 5
     )
 
     @Retry(count = 10)

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/AbstractQueuesSpec.groovy
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/AbstractQueuesSpec.groovy
@@ -37,7 +37,7 @@ abstract class AbstractQueuesSpec extends Specification {
         expect:
             expectedImplementation.isInstance(context.getBean(JobQueues))
         when:
-            for (i in 0..<100) {
+            for (i in 0..<500) {
                 if (sendWordsJob.words.size() >= 2) {
                     break
                 }

--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalJobExecutor.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalJobExecutor.java
@@ -18,6 +18,7 @@
 package com.agorapulse.worker.local;
 
 import com.agorapulse.worker.executor.DistributedJobExecutor;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Secondary;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Secondary
 @Singleton
+@Requires(property = "worker.executor.local.enabled", value = "true", defaultValue = "true")
 public class LocalJobExecutor implements DistributedJobExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalJobExecutor.class);

--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalQueues.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/local/LocalQueues.java
@@ -18,6 +18,7 @@
 package com.agorapulse.worker.local;
 
 import com.agorapulse.worker.queue.JobQueues;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.type.Argument;
@@ -33,6 +34,7 @@ import java.util.function.Consumer;
 @Secondary
 @Singleton
 @Named("local")
+@Requires(property = "worker.queues.local.enabled", value = "true", defaultValue = "true")
 public class LocalQueues implements JobQueues {
 
     private final ConcurrentMap<String, ConcurrentLinkedDeque<Object>> queues = new ConcurrentHashMap<>();

--- a/libs/micronaut-worker/src/main/java/com/agorapulse/worker/schedule/DefaultJobScheduler.java
+++ b/libs/micronaut-worker/src/main/java/com/agorapulse/worker/schedule/DefaultJobScheduler.java
@@ -80,7 +80,11 @@ public class DefaultJobScheduler implements JobScheduler, Closeable {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Scheduling cron job {} [{}] for {}", configuration.getName(), configuration.getCron(), job.getSource());
             }
-            taskScheduler.schedule(configuration.getCron(), job);
+            try {
+                taskScheduler.schedule(configuration.getCron(), job);
+            } catch (IllegalArgumentException e) {
+                throw new JobConfigurationException(job, "Failed to schedule job " + configuration.getName() + " declared in " + job.getSource() + ". Invalid CRON expression: " + configuration.getCron(), e);
+            }
         } else if (configuration.getFixedRate() != null) {
             Duration duration = configuration.getFixedRate();
             if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
to prevent crashing the application start up when the cron expression has wrong format