### PR TITLE
queue consumption improvements

### DIFF
--- a/docs/guide/src/docs/asciidoc/usage.adoc
+++ b/docs/guide/src/docs/asciidoc/usage.adoc
@@ -126,10 +126,14 @@ arguments they have and their return value.
 
 ==== Quick Start
 
-You can use two conventional annotations `@QueueProducer` and `@QueueConsumer` to publish and consume messages from a queue.
+You can use three conventional annotations `@QueueProducer`, `@QueueListener` and `@QueueConsumer` to publish and consume messages from a queue.
+
+`@QeueProducer` is used to publish messages to a queue, `@QueueListener` is used to poll messages from a queue and `@QueueConsumer` is used to consume messages from a queue. The difference between `@QueueListener` and `@QueueConsumer` is that the `@QueueListener` is triggered once using `initialDelay` and then polls the queue indefinitely until the application is terminated. The `@QueueConsumer` is triggered periodically using `fixedRate` and polls the queue for messages, at most `maxMessages` in a single job run.
+
+TIP: If you are in doubts, use `@QueueListener` to consume the messages from the queue as fast as possible. If you need more fine-grained control, use `@QueueConsumer`.
 
 [source,java]
-.Queue Producer and Consumer
+.Queue Quick Start
 ----
 include::{root-dir}/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/convention/QueueListenerAndProducerSpec.groovy[tag=quickstart,indent=0]
 ----
@@ -137,8 +141,10 @@ include::{root-dir}/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/
 <2> The producer jobs must have some scheduled trigger associated with them, for example cron or fixed rate
 <3> Use the `@QueueProducer` annotation with the name of the queue to publish messages
 <4> The producer job must return some value, ideally a `Publisher` of given messages
-<5> Use the `@QueueConsumer` annotation with the name of the queue to consume messages
+<5> Use the `@QueueListener` annotation with the name of the queue to poll the messages.
 <6> The consumer job must have a single parameter of the same type as the producer job returns
+<7> Use the `@QueueConsumer` annotation with the name of the queue to consume messages
+<8> The consumer job must have a single parameter of the same type as the producer job returns
 
 TIP: The value for `@Fork` is the same as the number of `maxMessages` for `@QueueConsumer` annotation. The value of `waitingTime` in `@QueueConsumer` is the same as the associated `@FixedRate` value.
 

--- a/libs/micronaut-worker-queues-redis/src/test/groovy/com/agorapulse/worker/queues/redis/RedisQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-redis/src/test/groovy/com/agorapulse/worker/queues/redis/RedisQueuesSpec.groovy
@@ -47,9 +47,11 @@ class RedisQueuesSpec extends AbstractQueuesSpec implements TestPropertyProvider
     @Override
     Map<String, String> getProperties() {
         return [
-            'redis.uri'                                : "redis://$redis.host:${redis.getMappedPort(6379)}",
-            'worker.jobs.send-words-job-listen.enabled': 'true',
-            'worker.jobs.send-words-job-hello.enabled' : 'true',
+            'redis.uri'                                   : "redis://$redis.host:${redis.getMappedPort(6379)}",
+            'worker.jobs.send-words-job-listen.enabled'   : 'true',
+            'worker.jobs.send-words-job-hello.enabled'    : 'true',
+            'worker.jobs.non-blocking-job-numbers.enabled': 'true',
+            'worker.jobs.non-blocking-job-consume.enabled': 'true',
         ]
     }
 

--- a/libs/micronaut-worker-queues-redis/src/test/groovy/com/agorapulse/worker/queues/redis/RedisQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-redis/src/test/groovy/com/agorapulse/worker/queues/redis/RedisQueuesSpec.groovy
@@ -47,11 +47,13 @@ class RedisQueuesSpec extends AbstractQueuesSpec implements TestPropertyProvider
     @Override
     Map<String, String> getProperties() {
         return [
-            'redis.uri'                                   : "redis://$redis.host:${redis.getMappedPort(6379)}",
-            'worker.jobs.send-words-job-listen.enabled'   : 'true',
-            'worker.jobs.send-words-job-hello.enabled'    : 'true',
-            'worker.jobs.non-blocking-job-numbers.enabled': 'true',
-            'worker.jobs.non-blocking-job-consume.enabled': 'true',
+            'redis.uri'                                        : "redis://$redis.host:${redis.getMappedPort(6379)}",
+            'worker.jobs.send-words-job-listen.enabled'        : 'true',
+            'worker.jobs.send-words-job-hello.enabled'         : 'true',
+            'worker.jobs.non-blocking-job-numbers.enabled'     : 'true',
+            'worker.jobs.non-blocking-job-consume.enabled'     : 'true',
+            'worker.jobs.non-blocking-job-more-numbers.enabled': 'true',
+            'worker.jobs.non-blocking-job-consume-ones.enabled': 'true',
         ]
     }
 

--- a/libs/micronaut-worker-queues-sqs-v1/src/main/java/com/agorapulse/worker/sqs/v1/SqsQueues.java
+++ b/libs/micronaut-worker-queues-sqs-v1/src/main/java/com/agorapulse/worker/sqs/v1/SqsQueues.java
@@ -18,6 +18,7 @@
 package com.agorapulse.worker.sqs.v1;
 
 import com.agorapulse.micronaut.aws.sqs.SimpleQueueService;
+import com.agorapulse.worker.convention.QueueListener;
 import com.agorapulse.worker.queue.JobQueues;
 import com.agorapulse.worker.queue.QueueMessage;
 import com.amazonaws.services.sqs.model.AmazonSQSException;
@@ -62,12 +63,16 @@ public class SqsQueues implements JobQueues {
                         0,
                         Math.min(MAX_WAITING_TIME, Math.toIntExact(waitTime.getSeconds())));
 
-                    if (messages.isEmpty() && waitTime.getSeconds() <= MAX_WAITING_TIME) {
+                    if (messages.isEmpty() && waitTime.getSeconds() <= MAX_WAITING_TIME && !QueueListener.Utils.isInfinitePoll(maxNumberOfMessages, waitTime)) {
                         sink.complete();
                         return 0;
                     }
 
                     sink.next(messages);
+
+                    if (QueueListener.Utils.isInfinitePoll(maxNumberOfMessages, waitTime)) {
+                        return maxNumberOfMessages;
+                    }
 
                     int nextRemaining = remainingNumberOfMessages - messages.size();
 

--- a/libs/micronaut-worker-queues-sqs-v1/src/test/groovy/com/agorapulse/worker/sqs/v1/SqsQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-sqs-v1/src/test/groovy/com/agorapulse/worker/sqs/v1/SqsQueuesSpec.groovy
@@ -30,6 +30,8 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 @Property(name = 'worker.jobs.send-words-job-hello.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-numbers.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-consume.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-more-numbers.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-consume-ones.enabled', value = 'true')
 @Property(name = 'non-blocking-job.delay', value = '500')
 class SqsQueuesSpec extends AbstractQueuesSpec {
 

--- a/libs/micronaut-worker-queues-sqs-v1/src/test/groovy/com/agorapulse/worker/sqs/v1/SqsQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-sqs-v1/src/test/groovy/com/agorapulse/worker/sqs/v1/SqsQueuesSpec.groovy
@@ -28,6 +28,8 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 @Property(name = 'aws.sqs.auto-create-queue', value = 'true')
 @Property(name = 'worker.jobs.send-words-job-listen.enabled', value = 'true')
 @Property(name = 'worker.jobs.send-words-job-hello.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-numbers.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-consume.enabled', value = 'true')
 class SqsQueuesSpec extends AbstractQueuesSpec {
 
     @SuppressWarnings('GetterMethodCouldBeProperty')

--- a/libs/micronaut-worker-queues-sqs-v1/src/test/groovy/com/agorapulse/worker/sqs/v1/SqsQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-sqs-v1/src/test/groovy/com/agorapulse/worker/sqs/v1/SqsQueuesSpec.groovy
@@ -30,6 +30,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 @Property(name = 'worker.jobs.send-words-job-hello.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-numbers.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-consume.enabled', value = 'true')
+@Property(name = 'non-blocking-job.delay', value = '500')
 class SqsQueuesSpec extends AbstractQueuesSpec {
 
     @SuppressWarnings('GetterMethodCouldBeProperty')

--- a/libs/micronaut-worker-queues-sqs-v2/src/main/java/com/agorapulse/worker/sqs/v2/SqsQueues.java
+++ b/libs/micronaut-worker-queues-sqs-v2/src/main/java/com/agorapulse/worker/sqs/v2/SqsQueues.java
@@ -27,14 +27,22 @@ import io.micronaut.jackson.JacksonConfiguration;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.SqsException;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class SqsQueues implements JobQueues {
+
+    private static final int MAX_MESSAGES_TO_POLL = 10;
+    private static final int MIN_PARALLELISM = 4;
+    private static final int MAX_WAITING_TIME = 20;
 
     private final SimpleQueueService simpleQueueService;
     private final ObjectMapper objectMapper;
@@ -46,16 +54,46 @@ public class SqsQueues implements JobQueues {
 
     @Override
     public <T> Publisher<QueueMessage<T>> readMessages(String queueName, int maxNumberOfMessages, Duration waitTime, Argument<T> argument) {
-        return Flux.merge(simpleQueueService.receiveMessages(queueName, maxNumberOfMessages, 0, Math.toIntExact(waitTime.getSeconds())).stream().map(m ->
-            readMessageInternal(queueName, argument, m.body(), true).map(
-                message -> QueueMessage.requeueIfDeleted(
-                    m.messageId(),
-                    message,
-                    () -> simpleQueueService.deleteMessage(queueName, m.receiptHandle()),
-                    () -> simpleQueueService.sendMessage(queueName, m.body())
+        Instant pollStart = Instant.now();
+        return Flux.<List<Message>, Integer>generate(() -> maxNumberOfMessages, (remainingNumberOfMessages, sink) -> {
+                try {
+                    List<Message> messages = simpleQueueService.receiveMessages(
+                        queueName,
+                        Math.min(MAX_MESSAGES_TO_POLL, remainingNumberOfMessages),
+                        0,
+                        Math.min(MAX_WAITING_TIME, Math.toIntExact(waitTime.getSeconds())));
+
+                    if (messages.isEmpty() && waitTime.getSeconds() <= MAX_WAITING_TIME) {
+                        sink.complete();
+                        return 0;
+                    }
+
+                    sink.next(messages);
+
+                    int nextRemaining = remainingNumberOfMessages - messages.size();
+
+                    if (nextRemaining <= 0 || pollStart.plus(waitTime).isBefore(Instant.now())) {
+                        sink.complete();
+                    }
+
+                    return nextRemaining;
+                } catch (Throwable th) {
+                    sink.error(th);
+                    return 0;
+                }
+            })
+            .flatMap(Flux::fromIterable)
+            .flatMap(m ->
+                readMessageInternal(queueName, argument, m.body(), true).map(
+                    message -> QueueMessage.requeueIfDeleted(
+                        m.messageId(),
+                        message,
+                        () -> simpleQueueService.deleteMessage(queueName, m.receiptHandle()),
+                        () -> simpleQueueService.sendMessage(queueName, m.body())
+                    )
                 )
             )
-        ).toList());
+            .parallel(Math.max(Schedulers.DEFAULT_POOL_SIZE, MIN_PARALLELISM));
     }
 
     @Override

--- a/libs/micronaut-worker-queues-sqs-v2/src/test/groovy/com/agorapulse/worker/sqs/v2/SqsQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-sqs-v2/src/test/groovy/com/agorapulse/worker/sqs/v2/SqsQueuesSpec.groovy
@@ -30,6 +30,8 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 @Property(name = 'worker.jobs.send-words-job-hello.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-numbers.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-consume.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-more-numbers.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-consume-ones.enabled', value = 'true')
 class SqsQueuesSpec extends AbstractQueuesSpec {
 
     @SuppressWarnings('GetterMethodCouldBeProperty')

--- a/libs/micronaut-worker-queues-sqs-v2/src/test/groovy/com/agorapulse/worker/sqs/v2/SqsQueuesSpec.groovy
+++ b/libs/micronaut-worker-queues-sqs-v2/src/test/groovy/com/agorapulse/worker/sqs/v2/SqsQueuesSpec.groovy
@@ -28,6 +28,8 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 @Property(name = 'aws.sqs.auto-create-queue', value = 'true')
 @Property(name = 'worker.jobs.send-words-job-listen.enabled', value = 'true')
 @Property(name = 'worker.jobs.send-words-job-hello.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-numbers.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-consume.enabled', value = 'true')
 class SqsQueuesSpec extends AbstractQueuesSpec {
 
     @SuppressWarnings('GetterMethodCouldBeProperty')

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/AbstractQueuesSpec.groovy
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/AbstractQueuesSpec.groovy
@@ -83,6 +83,16 @@ abstract class AbstractQueuesSpec extends Specification {
             nonBlockingJob.retrieved.last() % 3 == 0
     }
 
+    void 'can use infinite polling'() {
+        given:
+            PollingConditions pollingConditions = new PollingConditions(timeout: 30)
+
+        expect:
+            pollingConditions.eventually {
+                nonBlockingJob.ones.size() >= 30
+            }
+    }
+
     abstract Class<?> getExpectedImplementation()
     abstract String getName()
 

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/AbstractQueuesSpec.groovy
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/AbstractQueuesSpec.groovy
@@ -76,16 +76,11 @@ abstract class AbstractQueuesSpec extends Specification {
 
         expect:
             pollingConditions.eventually {
-                nonBlockingJob.retrieved.size() >= 10
+                nonBlockingJob.retrieved.size() == 20
             }
 
             nonBlockingJob.retrieved
-
-        when:
-            List<Integer> reversed = nonBlockingJob.retrieved.reverse()
-        then:
-            reversed.take(3).every { it % 3 == 0 }
-
+            nonBlockingJob.retrieved.last() % 3 == 0
     }
 
     abstract Class<?> getExpectedImplementation()

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/NonBlockingJob.java
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/NonBlockingJob.java
@@ -1,0 +1,40 @@
+package com.agorapulse.worker.tck.queue;
+
+import com.agorapulse.worker.annotation.InitialDelay;
+import com.agorapulse.worker.convention.QueueConsumer;
+import com.agorapulse.worker.convention.QueueProducer;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.IntStream;
+
+@Singleton
+public class NonBlockingJob {
+
+    public record NumberMessage(int number) { }
+
+    private final List<Integer> retrieved = new CopyOnWriteArrayList<>();
+
+    @InitialDelay("10ms")
+    @QueueProducer("numbers")
+    public Publisher<NumberMessage> numbers() {
+        return Flux.range(1, 20).map(NumberMessage::new);
+    }
+
+    @QueueConsumer("numbers")
+    public void consume(NumberMessage message) throws InterruptedException {
+        System.out.println(message);
+        if (message.number() % 3 == 0) {
+            Thread.sleep(100);
+        }
+        retrieved.add(message.number);
+    }
+
+    public List<Integer> getRetrieved() {
+        return retrieved;
+    }
+
+}

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/NonBlockingJob.java
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/NonBlockingJob.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2021-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.worker.tck.queue;
 
 import com.agorapulse.worker.annotation.FixedRate;

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/NonBlockingJob.java
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/queue/NonBlockingJob.java
@@ -3,20 +3,27 @@ package com.agorapulse.worker.tck.queue;
 import com.agorapulse.worker.annotation.InitialDelay;
 import com.agorapulse.worker.convention.QueueConsumer;
 import com.agorapulse.worker.convention.QueueProducer;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.IntStream;
 
 @Singleton
+@Requires(env = AbstractQueuesSpec.QUEUE_SPEC_ENV_NAME)
 public class NonBlockingJob {
 
     public record NumberMessage(int number) { }
 
     private final List<Integer> retrieved = new CopyOnWriteArrayList<>();
+    private final long delay;
+
+    public NonBlockingJob(@Value("${non-blocking-job.delay:100}") long delay) {
+        this.delay = delay;
+    }
 
     @InitialDelay("10ms")
     @QueueProducer("numbers")
@@ -24,11 +31,10 @@ public class NonBlockingJob {
         return Flux.range(1, 20).map(NumberMessage::new);
     }
 
-    @QueueConsumer("numbers")
+    @QueueConsumer(value = "numbers", maxMessages = 20)
     public void consume(NumberMessage message) throws InterruptedException {
-        System.out.println(message);
         if (message.number() % 3 == 0) {
-            Thread.sleep(100);
+            Thread.sleep(delay);
         }
         retrieved.add(message.number);
     }

--- a/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/convention/QueueListenerAndProducerSpec.groovy
+++ b/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/convention/QueueListenerAndProducerSpec.groovy
@@ -41,8 +41,13 @@ class QueueListenerAndProducerSpec extends Specification {
         return Flux.just("Hello", "World").map(Message::new);
     }
 
-    @QueueConsumer("my-queue")                                                          // <5>
+    @QueueListener("my-queue")                                                          // <5>
     public void listenToMyQueue(Message message) {                                      // <6>
+        // your code here
+    }
+
+    @QueueConsumer("my-queue")                                                          // <7>
+    public void consumeToMyQueue(Message message) {                                     // <8>
         // your code here
     }
     // end::quickstart[]

--- a/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/local/LocalQueuesSpec.groovy
+++ b/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/local/LocalQueuesSpec.groovy
@@ -28,6 +28,8 @@ import jakarta.inject.Inject
 @Property(name = 'worker.jobs.send-words-job-hello.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-numbers.enabled', value = 'true')
 @Property(name = 'worker.jobs.non-blocking-job-consume.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-more-numbers.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-consume-ones.enabled', value = 'true')
 class LocalQueuesSpec extends AbstractQueuesSpec {
 
     @Inject LocalQueues queues

--- a/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/local/LocalQueuesSpec.groovy
+++ b/libs/micronaut-worker/src/test/groovy/com/agorapulse/worker/local/LocalQueuesSpec.groovy
@@ -26,6 +26,8 @@ import jakarta.inject.Inject
 @MicronautTest(environments = AbstractQueuesSpec.QUEUE_SPEC_ENV_NAME)
 @Property(name = 'worker.jobs.send-words-job-listen.enabled', value = 'true')
 @Property(name = 'worker.jobs.send-words-job-hello.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-numbers.enabled', value = 'true')
+@Property(name = 'worker.jobs.non-blocking-job-consume.enabled', value = 'true')
 class LocalQueuesSpec extends AbstractQueuesSpec {
 
     @Inject LocalQueues queues


### PR DESCRIPTION
* adds ability to set the maximum number of messages higher than native restriction to consume more in messages within one consumer job trigger
* adds new `@QueueListener` annotation that is a conventional shortcut for a long polling job
  * this jobs starts after initial delay (30 seconds by default)
  * this jobs constantly poll the queue for new incoming messages and is executed every incoming message