### PR TITLE
fix: wire gitPublish HTTPS credentials so :guide:gitPublishPush succeeds

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -26,9 +26,11 @@ jobs:
           git config --global user.name 'Agorapulse Bot'
           git config --global user.email 'oss@agorapulse.com'
       - name: Publish GitHub Pages
+        env:
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
         run: |
           ./gradlew :guide:gitPublishPush \
             -Pversion=${{ steps.latest_version.outputs.latest_tag }} \
             -Prelease=true \
-            -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }} \
             --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,14 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
         run: |
           ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
             -Pversion=${{ steps.version.outputs.tag }} \
             -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
             -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
             -Prelease=true \
-            -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }} \
             --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -19,6 +19,14 @@ plugins {
     id 'com.agorapulse.gradle.guide'
 }
 
+// gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars
+// (or the org.ajoberstar.grgit.auth.* system properties). HTTPS push
+// credentials must be set on the gitPublish extension directly.
+gitPublish {
+    username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
+    password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
+}
+
 asciidoctor {
     baseDirFollowsSourceDir()
 


### PR DESCRIPTION
## Summary

The 3.0.0.RC1 Release workflow [failed](https://github.com/agorapulse/micronaut-worker/actions/runs/26406023943) on `:guide:gitPublishPush`:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Tag exists, but no artifact has been pushed to Maven Central yet.

## Fix

gradle-git-publish 5.x no longer reads `GRGIT_USER` / `GRGIT_PASS` env vars or the `org.ajoberstar.grgit.auth.*` system properties — HTTPS push credentials have to be set on the gitPublish extension directly. Mirror the fix gru and log4aws already shipped:

* `docs/guide/guide.gradle` — read `GIT_PUBLISH_USERNAME` / `GIT_PUBLISH_PASSWORD` env vars into the `gitPublish` extension.
* `.github/workflows/release.yml` — pass those env vars into the Release step, drop the legacy `-Dorg.ajoberstar.grgit.auth.username` system property.
* `.github/workflows/publish-documentation.yml` — same env wiring for the manual docs publish.

## After merge

The 3.0.0.RC1 tag needs to be deleted + re-cut so the Release workflow can actually publish.

## Test plan
- [x] `./gradlew :guide:asciidoctor` succeeds locally (guide compiles with the new `gitPublish` block)
- [ ] CI green on this PR
- [ ] Delete + retag 3.0.0.RC1 once merged
