### PR TITLE
chore: bump micronaut-snitch to 3.0.0.RC1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ micronautGradlePluginVersion=5.0.0
 
 testcontainersVersion=1.20.3
 micronautAwsSdkVersion=5.0.0.RC2
-micronautSnitchVersion=2.0.0
+micronautSnitchVersion=3.0.0.RC1
 micronautConsoleVersion=5.0.0.RC3
 closureSupportVersion=1.0.1
 gruVersion=3.0.0.RC2


### PR DESCRIPTION
## Summary

Lifts worker's last Mn 4-era pin (`micronautSnitchVersion=2.0.0`) to match the rest of the Mn 5 / Java 25 / Agorapulse-plugins baseline.

`micronaut-snitch:3.0.0.RC1` shipped alongside the rest of the OSS Mn 5 migration (full Kordamp → Agorapulse Gradle Plugins switch, `javaVersion=25`, `micronautVersion=5.0.0`).

## Notes

snitch is `compileOnly` here, so the bump is mostly cosmetic — it keeps the version graph honest and lets a future worker release ship without a stale 2.0.0 transitive reference.

## Test plan
- [x] `./gradlew check --rerun-tasks` passes locally on JDK 25 / Gradle 9.5
- [ ] CI green on this PR
