### PR TITLE
fix(deps): bump micronaut-aws-sdk pin 5.0.0.RC2 -> 5.0.0.RC3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ micronautVersion=5.0.0
 micronautGradlePluginVersion=5.0.0
 
 testcontainersVersion=1.20.3
-micronautAwsSdkVersion=5.0.0.RC2
+micronautAwsSdkVersion=5.0.0.RC3
 micronautSnitchVersion=3.0.0.RC1
 micronautConsoleVersion=5.0.0.RC3
 closureSupportVersion=1.0.1


### PR DESCRIPTION
## Problem

The `3.0.0.RC3` release pins `com.agorapulse:micronaut-aws-sdk` at `5.0.0.RC2`
via `micronautAwsSdkVersion` in `gradle.properties`. RC2 of the
`micronaut-aws-sdk-dependencies` BOM carries a bogus
`com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:3.0.0` constraint
that does not exist on Maven Central, which breaks `compileClasspath`
resolution for every downstream consumer of `micronaut-worker-queues-sqs-v2`:

```
project:<app>
  > com.agorapulse:micronaut-worker-queues-sqs-v2:3.0.0.RC3
    > com.agorapulse:micronaut-amazon-awssdk-sqs:5.0.0.RC2
      > com.agorapulse:micronaut-aws-sdk-dependencies:5.0.0.RC2
        Could not find com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:3.0.0
```

The bad cbor constraint was already removed upstream in
`micronaut-aws-sdk:5.0.0.RC3` (agorapulse/micronaut-aws-sdk#354). Bumping the
worker's pin to RC3 restores clean resolution.

This is blocking the Micronaut 5 upgrade in `agorapulse/platform` PR #75744.

## Change

`gradle.properties`: `micronautAwsSdkVersion=5.0.0.RC2` -> `5.0.0.RC3`

The test-only pin `micronaut-log4aws:5.0.0.RC2` in `build.gradle` is left
untouched: `micronaut-log4aws` was never published at `5.0.0.RC3` (latest on
Central is RC2), it is `testImplementation`-scoped in the `:guide` module, and
is not propagated to published consumer artifacts.

## Verification (local, JDK 25 + Gradle 9.5)

- `./gradlew :micronaut-worker-queues-sqs-v2:dependencies` resolves cleanly and
  now pulls `com.agorapulse:micronaut-aws-sdk-dependencies:5.0.0.RC3`.
- No `jackson-dataformat-cbor` line anywhere on `compileClasspath` /
  `runtimeClasspath` (the bogus `3.0.0` constraint is gone).
- `./gradlew :micronaut-worker-queues-sqs-v2:publishToMavenLocal -Pversion=3.0.0.RC4`
  compiles, jars and generates the POM successfully; the generated POM declares
  `micronaut-amazon-awssdk-sqs:5.0.0.RC3`. (Only `signMavenPublication` fails
  locally for the expected reason — no PGP key in this environment.)

## Follow-up

After merge, publish a `3.0.0.RC4` GitHub Release (triggers `release.yml` ->
Maven Central). Once RC4 is synced, the downstream override
`micronautWorkerVersion=3.0.0.RC3` in the platform backends can be bumped to
`3.0.0.RC4`.

https://claude.ai/code/session_012tZogyXLxDzDRXQinqQ8dk

---
_Generated by [Claude Code](https://claude.ai/code/session_012tZogyXLxDzDRXQinqQ8dk)_