### PR TITLE
chore(deps): bump Micronaut to 5.0.6 and Agorapulse deps to GA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ gradleProjects {
 
                 compileOnly 'io.micronaut:micronaut-inject-groovy'
 
-                testImplementation 'com.agorapulse:micronaut-log4aws:5.0.0.RC2'
+                testImplementation 'com.agorapulse:micronaut-log4aws:5.0.0'
                 testImplementation 'io.micronaut:micronaut-inject-groovy'
 
                 testImplementation(group: 'org.testcontainers', name: 'spock', version: project.testcontainersVersion)

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,15 +29,15 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 
-micronautVersion=5.0.0
-micronautGradlePluginVersion=5.0.0
+micronautVersion=5.0.6
+micronautGradlePluginVersion=5.0.2
 
 testcontainersVersion=1.20.3
-micronautAwsSdkVersion=5.0.0.RC3
-micronautSnitchVersion=3.0.0.RC1
-micronautConsoleVersion=5.0.0.RC3
+micronautAwsSdkVersion=5.0.0
+micronautSnitchVersion=3.0.0
+micronautConsoleVersion=5.0.0
 closureSupportVersion=1.0.1
-gruVersion=3.0.0.RC2
+gruVersion=3.0.0
 lettuceVersion=5.2.1.RELEASE
 byteBuddyVersion=1.10.22
 testRetryPluginVersion=1.5.0


### PR DESCRIPTION
Bumps Micronaut to `5.0.6` (Gradle plugin `5.0.2`) and moves every Agorapulse dependency off its RC pin onto the new GA line: gru `3.0.0`, micronaut-aws-sdk `5.0.0`, micronaut-snitch `3.0.0`, micronaut-console `5.0.0`, and micronaut-log4aws `5.0.0` (test). Final wave of the MN 5.0.6 OSS release train — ships as micronaut-worker `3.0.0` GA.