### PR TITLE
chore(deps): bump Micronaut to 5.1.0, propagate GA deps, fix guide

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ gradleProjects {
 
                 compileOnly 'io.micronaut:micronaut-inject-groovy'
 
-                testImplementation 'com.agorapulse:micronaut-log4aws:5.0.0'
+                testImplementation 'com.agorapulse:micronaut-log4aws:5.0.2'
                 testImplementation 'io.micronaut:micronaut-inject-groovy'
 
                 testImplementation(group: 'org.testcontainers', name: 'spock', version: project.testcontainersVersion)

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -34,6 +34,9 @@ asciidoctor {
         'gradle-version': project.gradle.gradleVersion,
         'source-highlighter': 'prettify',
         'root-dir': rootDir,
-        'project-slug': slug
+        'project-slug': slug,
+        'project-title': 'Micronaut Worker',
+        'project-version': project.version,
+        'project-author': 'Agorapulse'
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,15 +29,15 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 
-micronautVersion=5.0.6
+micronautVersion=5.1.0
 micronautGradlePluginVersion=5.0.2
 
 testcontainersVersion=1.20.3
-micronautAwsSdkVersion=5.0.0
-micronautSnitchVersion=3.0.0
-micronautConsoleVersion=5.0.0
+micronautAwsSdkVersion=5.0.1
+micronautSnitchVersion=3.0.1
+micronautConsoleVersion=5.0.2
 closureSupportVersion=1.0.1
-gruVersion=3.0.0
+gruVersion=3.0.2
 lettuceVersion=5.2.1.RELEASE
 byteBuddyVersion=1.10.22
 testRetryPluginVersion=1.5.0

--- a/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/event/JobExecutionRecorder.java
+++ b/libs/micronaut-worker-tck/src/main/groovy/com/agorapulse/worker/tck/event/JobExecutionRecorder.java
@@ -78,9 +78,4 @@ public class JobExecutionRecorder implements RefreshEventListener {
         resultEvents.clear();
     }
 
-    @Override
-    public String toString() {
-        return "JobExecutionRecorder{startedEvents=%s, finishedEvents=%s, resultEvents=%s}".formatted(startedEvents, finishedEvents, resultEvents);
-    }
-
 }


### PR DESCRIPTION
Bumps Micronaut 5.0.6 -> 5.1.0 (plugin stays 5.0.2) and propagates the GA dependency chain: gru 3.0.2, aws-sdk 5.0.1, console 5.0.2, snitch 3.0.1, log4aws 5.0.2. Fixes the guide rendering literal {project-title}/{project-version}. Works around a Micronaut 5.1.0 AOP-proxy codegen regression (duplicate `toString` in the generated `$Intercepted` for the TCK `JobExecutionRecorder`) by dropping that helper's `toString()` override. Ships as micronaut-worker 3.0.1.