### PR TITLE
Depend on micronaut-redis-lettuce-core in the redis executor and queues

### DIFF
--- a/libs/micronaut-worker-executor-redis/micronaut-worker-executor-redis.gradle
+++ b/libs/micronaut-worker-executor-redis/micronaut-worker-executor-redis.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     api "io.lettuce:lettuce-core:$lettuceVersion"
 
-    implementation 'io.micronaut.redis:micronaut-redis-lettuce'
+    implementation 'io.micronaut.redis:micronaut-redis-lettuce-core'
     implementation 'io.micronaut.reactor:micronaut-reactor'
 
     testImplementation project(':micronaut-worker-tck')

--- a/libs/micronaut-worker-queues-redis/micronaut-worker-queues-redis.gradle
+++ b/libs/micronaut-worker-queues-redis/micronaut-worker-queues-redis.gradle
@@ -18,7 +18,7 @@
 
 dependencies {
     api project(':micronaut-worker')
-    implementation 'io.micronaut.redis:micronaut-redis-lettuce'
+    implementation 'io.micronaut.redis:micronaut-redis-lettuce-core'
     implementation 'io.micronaut:micronaut-jackson-databind'
 
     testImplementation project(':micronaut-worker-tck')


### PR DESCRIPTION
## Why

Micronaut Redis 7.0 split `micronaut-redis-lettuce` into `-core`, `-cache`, `-session` and `-pubsub`, and turned the old coordinate into an aggregate that depends on all of them at `compile` scope:

```
io.micronaut.redis:micronaut-redis-lettuce:7.1.0
  → micronaut-redis-lettuce-core     (compile)
  → micronaut-redis-lettuce-cache    (compile)
  → micronaut-redis-lettuce-session  (compile)
      → io.micronaut.session:micronaut-session:5.1.0
```

Under Micronaut 4 (`micronaut-redis` 6.9.0) the same coordinate declared only `micronaut-inject`, `lettuce-core` and `micronaut-cache-core` — no session module. So consumers of `micronaut-worker-executor-redis` and `micronaut-worker-queues-redis` silently gained `micronaut-session` on their runtime classpath when they moved to Micronaut 5.

That is not harmless. `micronaut-session` contributes a `SessionArgumentBinder` to `DefaultRequestBinderRegistry`, so building **any** outbound `@Client` bean now instantiates `SessionConfiguration`. On Micronaut 5.1.1 that nested lookup trips a `ConcurrentModificationException` inside the framework's own `DefaultBeanDefinitionService$2$1.advance` — a class that did not exist in Micronaut 4. We hit it in production as a `BeanInstantiationException` on an internal HTTP client in a worker app.

## What

Both redis modules now ask for `micronaut-redis-lettuce-core`, which is all they use.

## Verification

Neither module touches the cache, session or pubsub API — the complete set of relevant imports across both `src/main` trees is:

```
io.lettuce.core.RedisClient
io.lettuce.core.ScriptOutputType
io.lettuce.core.TransactionResult
io.lettuce.core.api.StatefulRedisConnection
io.lettuce.core.api.async.RedisAsyncCommands
io.lettuce.core.api.sync.RedisCommands
io.lettuce.core.support.{AsyncObjectFactory, BasePoolConfig, BoundedAsyncPool, BoundedPoolConfig}
```

Every one of those beans is provided by `-core`.

Note on scope: `micronaut-cache-core` was reaching consumers transitively through the old aggregate, at `implementation` scope. Anything that relies on a Micronaut cache should be declaring it, and in the monorepo that consumes these libraries every such project already does or has been fixed to.

I could not run a local build to confirm — this repo's settings-plugin classpath requires a Java 25 *runtime* and only JDK 21 was available in my environment. CI needs to be the check here.

## Related

Companion changes making the same fix on the other two hops in the chain: `agorapulse/platform-commons` (`commons-redis-toolbox`) and `agorapulse/platform` (56 projects). Release order matters — this repo first, then `platform-commons`, then `platform`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Keyj7CtFkeL4P3HawX3M99)_