### PR TITLE
fix: keep the raw body fallback reachable under Jackson 3

### DIFF
--- a/libs/micronaut-worker-queues-redis/src/main/java/com/agorapulse/worker/queues/redis/RedisQueues.java
+++ b/libs/micronaut-worker-queues-redis/src/main/java/com/agorapulse/worker/queues/redis/RedisQueues.java
@@ -107,7 +107,7 @@ public class RedisQueues implements JobQueues {
         try {
             String item = jsonMapper.writeValueAsString(result);
             sendRawMessage(queueName, item);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             throw new IllegalArgumentException("Cannot write " + result + " to JSON", e);
         }
     }
@@ -151,7 +151,10 @@ public class RedisQueues implements JobQueues {
     private <T> Mono<QueueMessage<T>> readMessageInternalWithFallback(String queueName, Argument<T> argument, String body) {
         try {
             return Mono.just(readMessageInternal(queueName, argument, body));
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
+            // Jackson 2's mapping exceptions extended IOException; Jackson 3's
+            // tools.jackson.core.JacksonException is a plain RuntimeException,
+            // so widen the catch to keep the raw body fallback reachable.
             if (argument.equalsType(Argument.STRING)) {
                 return Mono.just(QueueMessage.alwaysRequeue(
                     UUID.randomUUID().toString(),

--- a/libs/micronaut-worker-queues-sqs-v2/src/main/java/com/agorapulse/worker/sqs/v2/SqsQueues.java
+++ b/libs/micronaut-worker-queues-sqs-v2/src/main/java/com/agorapulse/worker/sqs/v2/SqsQueues.java
@@ -131,7 +131,10 @@ public class SqsQueues implements JobQueues {
     private <T> Mono<T> readMessageInternal(String queueName, Argument<T> argument, String body, boolean tryReformat) {
         try {
             return Mono.just(jsonMapper.readValue(body, argument));
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
+            // Jackson 2's mapping exceptions extended IOException; Jackson 3's
+            // tools.jackson.core.JacksonException is a plain RuntimeException,
+            // so widen the catch to keep the raw body fallback reachable.
             if (tryReformat) {
                 if (String.class.isAssignableFrom(argument.getType())) {
                     return Mono.just(argument.getType().cast(body));

--- a/libs/micronaut-worker-queues-sqs-v2/src/test/groovy/com/agorapulse/worker/sqs/v2/SqsQueuesUnitSpec.groovy
+++ b/libs/micronaut-worker-queues-sqs-v2/src/test/groovy/com/agorapulse/worker/sqs/v2/SqsQueuesUnitSpec.groovy
@@ -96,6 +96,24 @@ class SqsQueuesUnitSpec extends Specification {
             }
     }
 
+    void 'object payload falls back to the raw body for a string argument'() {
+        when:
+            List<String> values = Flux.from(
+                sqsQueues.readMessages(QUEUE_NAME, 1, WAIT_TIME, Argument.STRING)
+            ).map(QueueMessage::getMessage).collectList().block()
+        then:
+            values == ['{"key":"value"}']
+
+            1 * simpleQueueService.receiveMessages(QUEUE_NAME, 1, 0, WAIT_TIME.seconds) >> {
+                [
+                    Message.builder()
+                        .body('{"key":"value"}')
+                        .receiptHandle('one')
+                        .build(),
+                ]
+            }
+    }
+
     void 'message not deleted on error'() {
         when:
             Flux.from(


### PR DESCRIPTION
## Problem

A queue listener that declares a `String` payload while the producer sends an object used to work: `SqsQueues` failed to bind the JSON, caught the failure and handed the raw message body to the job. Since Micronaut 5 that fallback is dead code.

Micronaut 5 ships Jackson 3, where mapping failures (`tools.jackson.databind.exc.MismatchedInputException` and friends) are plain `RuntimeException`s. Jackson 2 derived them from `IOException`, which is what both queue implementations catch, so the failure now escapes the fallback, kills the job, and — with SQS — the message is never deleted and gets redelivered forever.

Observed in production as a redelivery loop on `report-worker-beta` after the consumer's first run following the Micronaut 5 upgrade (Sentry `REPORT-WORKER-BETA-9G`).

## Change

- `SqsQueues.readMessageInternal` and `RedisQueues.readMessageInternalWithFallback` now catch `IOException | RuntimeException`, so the raw-body and legacy-collection fallbacks are reached again under either Jackson generation. Bodies that no fallback can handle still surface as `IllegalArgumentException`, unchanged.
- `RedisQueues.sendMessage` gets the same widening on the write path, matching what `SqsQueues.convertMessageToJson` already does.
- New regression spec in `SqsQueuesUnitSpec`: an object body read as `Argument.STRING` must come back as the raw body. It fails on `master` with `MismatchedInputException`.

## Verification

`:micronaut-worker-queues-sqs-v2:test --tests '*SqsQueuesUnitSpec*'` fails before the source change and passes after; the redis module compiles. The container-backed specs (`SqsQueuesSpec`, `RedisQueuesSpec`) need Docker and were left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6cxwHXvohh6A7M8216hGT)_